### PR TITLE
Switch html_show_sourcelink flag to True, resolves #3269.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -217,7 +217,7 @@ html_sidebars = {'**': ['index.html']}
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True


### PR DESCRIPTION
## What do these changes do?

Edits conf.py so that source link is shown on all pages. 

## Related issue number

This should fix issue #3269.
